### PR TITLE
Update requirements versions, move some to run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - litellm = litellm:run_server
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,7 +23,6 @@ requirements:
     - wheel
     - pip
   run:
-    - uvloop <0.22.0,>=0.21.0
     - httpx >=0.23.0
     - python >={{ python_min }}
     - openai >=1.61.0
@@ -34,28 +33,27 @@ requirements:
     - click
     - jinja2 >=3.1.2,<4.0.0
     - aiohttp
-    - requests >=2.31.0,<3.0.0
     - pydantic >=2.0.0,<3.0.0
     - jsonschema >=4.22.0,<5.0.0
   run_constrained:
-    - uvicorn >=0.22.0,<0.23.0
+    - uvicorn >=0.29.0,<0.30.0
+    - uvloop >=0.21.0,<0.22.0
     - gunicorn >=22.0.0,<23.0.0
-    - fastapi >=0.111.0,<1.0.0
-    - backoff *
+    - fastapi >=0.111.5,<1.0.0
     - pyyaml >=6.0.1,<7.0.0
-    - rq *
     - orjson >=3.9.7,<4.0.0
     - apscheduler >=3.10.4,<4.0.0
-    - fastapi-sso >=0.10.0,<0.11.0
-    - PyJWT >=2.8.0,<3.0.0
-    - python-multipart >=0.0.9,<0.0.10
-    - cryptography 42.0.5
-    - prisma >=0.11.0,<0.12.0
+    - pyjwt >=2.8.0,<3.0.0
+    - python-multipart >=0.0.18,<0.0.19
+    - cryptography >=43.0.1,<44.0.0
     - azure-identity >=1.15.0,<2.0.0
     - azure-keyvault-secrets >=4.8.0,<5.0.0
     - google-cloud-kms >=2.21.3,<3.0.0
-    - resend >=0.8.0,<1.0.0
     - pynacl >=1.5.0,<2.0.0
+    # not yet available on conda-forge
+    - prisma >=0.11.0,<0.12.0
+    - resend >=0.8.0,<0.9.0
+    - fastapi-sso >=0.16.0,<0.17.0
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I wanted to update to version 1.2 of [notebook-intelligence](https://github.com/conda-forge/notebook_intelligence-feedstock) but was unable to:
```shell
conda install "notebook_intelligence=1.2"

LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides uvloop <0.22.0,>=0.21.0 needed by litellm-1.62.1-pyhd8ed1ab_0

Could not solve for environment specs
The following package could not be installed
└─ notebook_intelligence =1.2 * is not installable because it requires
   └─ litellm >=1.62.1 *, which requires
      └─ uvloop <0.22.0,>=0.21.0 *, which does not exist (perhaps a missing channel).
```
`uvloop` is missing on Windows (https://github.com/conda-forge/uvloop-feedstock/issues/23), quick research showed `uvloop` is an optional requirement of `litellm`. So this MR updates/moves some requirements.