### PR TITLE
Remove problematic upper bounds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - litellm = litellm:run_server
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,7 +23,7 @@ requirements:
     - wheel
     - pip
   run:
-    - pondpond >=1.4.1,<2.0.0
+    - pondpond >=1.4.1
     - fastuuid >=0.13.0
     - httpx >=0.23.0
     - python >={{ python_min }}
@@ -33,37 +33,37 @@ requirements:
     - importlib-metadata >=6.8.0
     - tokenizers
     - click
-    - jinja2 >=3.1.2,<4.0.0
+    - jinja2 >=3.1.2
     - aiohttp >=3.10
-    - pydantic >=2.5.0,<3.0.0
-    - jsonschema >=4.22.0,<5.0.0
+    - pydantic >=2.5.0
+    - jsonschema >=4.22.0
   run_constrained:
-    - uvicorn >=0.29.0,<0.30.0
-    - uvloop >=0.21.0,<0.22.0
-    - gunicorn >=23.0.0,<24.0.0
-    - fastapi >=0.115.5,<1.0.0
-    - pyyaml >=6.0.1,<7.0.0
-    - orjson >=3.9.7,<4.0.0
-    - apscheduler >=3.10.4,<4.0.0
-    - pyjwt >=2.8.0,<3.0.0
-    - python-multipart >=0.0.18,<0.0.19
-    - cryptography >=43.0.1,<44.0.0
-    - azure-identity >=1.15.0,<2.0.0
-    - azure-keyvault-secrets >=4.8.0,<5.0.0
-    - google-cloud-kms >=2.21.3,<3.0.0
-    - pynacl >=1.5.0,<2.0.0
-    - websockets >=13.1.0,14.0.0
-    - boto3 >=1.34.34,<2.0.0
-    - mcp >=1.9.3,<2.0.0
-    - rich >13.7.1,<14.0.0
-    - diskcache >=5.6.1,<6.0.0
+    - uvicorn >=0.29.0
+    - uvloop >=0.21.0
+    - gunicorn >=23.0.0
+    - fastapi >=0.115.5
+    - pyyaml >=6.0.1
+    - orjson >=3.9.7
+    - apscheduler >=3.10.4
+    - pyjwt >=2.8.0
+    - python-multipart >=0.0.18
+    - cryptography >=43.0.1
+    - azure-identity >=1.15.0
+    - azure-keyvault-secrets >=4.8.0
+    - google-cloud-kms >=2.21.3
+    - pynacl >=1.5.0
+    - websockets >=13.1.0
+    - boto3 >=1.34.34
+    - mcp >=1.9.3
+    - rich >13.7.1
+    - diskcache >=5.6.1
     # not yet available on conda-forge
-    - prisma >=0.11.0,<0.12.0
-    - resend >=0.8.0,<0.9.0
-    - fastapi-sso >=0.16.0,<0.17.0
-    - redisvl >=0.4.1,<0.5.0
-    - litellm-proxy-extras >=0.2.6,<0.3.0
-    - litellm-enterprise >=0.1.10,<0.2.0
+    - prisma >=0.11.0
+    - resend >=0.8.0
+    - fastapi-sso >=0.16.0
+    - redisvl >=0.4.1
+    - litellm-proxy-extras >=0.2.6
+    - litellm-enterprise >=0.1.10
 
 test:
   imports:


### PR DESCRIPTION
The upper bounds are a well-known bad practice[1] and are causing needless dependency conflicts for consumers. They were doubtless added in the first place via blind translation of the poetry `^X.Y.Z` constraints[2] rather than deliberately based on known incompatibility.

[1] https://iscinumpy.dev/post/bound-version-constraints/
[2] https://github.com/BerriAI/litellm/blob/main/pyproject.toml

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Should also be addressed in the upstream pyproject.toml so this doesn't happen the next time this conda package is auto-updated from a new version, but that need not block fixing current consumers of this package.